### PR TITLE
Add GitHub Actions workflow to build .NET solution on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore backend/src/Intelligence.TradeSystem.slnx
+
+      - name: Build
+        run: dotnet build backend/src/Intelligence.TradeSystem.slnx --configuration Release --no-restore


### PR DESCRIPTION
### Motivation
- Add a CI workflow to validate that the .NET solution at `backend/src/Intelligence.TradeSystem.slnx` restores and builds on pull requests and manual triggers.

### Description
- Add `.github/workflows/build.yml` which checks out the repo, sets up .NET via `actions/setup-dotnet@v4` (targeting `10.0.x`), runs `dotnet restore backend/src/Intelligence.TradeSystem.slnx`, and runs `dotnet build backend/src/Intelligence.TradeSystem.slnx --configuration Release --no-restore`.

### Testing
- The workflow configures automated steps `dotnet restore` and `dotnet build` to run on `pull_request` events and `workflow_dispatch`, and no test suites are executed by this workflow beyond the build steps; the workflow has not been executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95e7f76d083228fdc5ee29a86c5a6)